### PR TITLE
Fix imported domain cookies becoming host-only

### DIFF
--- a/src/pages/Extension_import/index.jsx
+++ b/src/pages/Extension_import/index.jsx
@@ -3,6 +3,7 @@ import {image} from "../../utils/images";
 import {useEffect, useState} from "react";
 import CryptoJS from "crypto-js";
 import {extension} from "../../utils/chrome";
+import {createCookieSetDetails} from "../../utils/cookie_import";
 
 const ExtensionImport = () => {
     const [isLoading, setIsLoading] = useState(false);
@@ -18,17 +19,7 @@ const ExtensionImport = () => {
     const handleImportCookieJson = async (dataCookies) => {
         let cookies = typeof dataCookies === "string" ? JSON.parse(dataCookies) : dataCookies
         for (let i = 0; i < cookies.length; i++) {
-            const dataUpdate = {
-                expirationDate: cookies[i].expirationDate,
-                httpOnly: cookies[i].httpOnly,
-                name: cookies[i].name,
-                value: cookies[i].value,
-                sameSite: cookies[i].sameSite,
-                path: cookies[i].path,
-                secure: cookies[i].secure,
-                storeId: cookies[i].storeId,
-                url: cookieInfo.domain
-            }
+            const dataUpdate = createCookieSetDetails(cookies[i], cookieInfo.domain);
             await chrome.cookies.set(dataUpdate);
             if (i === cookies.length - 1) {
                 window.location.replace(cookieInfo.domain);

--- a/src/pages/Extension_sidepanel/components/popup/import_cookie/index.jsx
+++ b/src/pages/Extension_sidepanel/components/popup/import_cookie/index.jsx
@@ -8,6 +8,7 @@ import {extension} from "../../../../../utils/chrome";
 import {observer} from "mobx-react-lite";
 import {settingStore} from "../../../../../mobx/setting.store";
 import {useClickOutside} from "../../../../../hooks/useClickOutside";
+import {createCookieSetDetails} from "../../../../../utils/cookie_import";
 
 const ImportCookie = () => {
     const ref = useRef(null);
@@ -44,17 +45,7 @@ const ImportCookie = () => {
     const handleImportCookieJson = async (dataCookies) => {
         let cookies = typeof dataCookies === "string" ? JSON.parse(dataCookies) : dataCookies
         for (let i = 0; i < cookies.length; i++) {
-            const dataUpdate = {
-                expirationDate: cookies[i].expirationDate,
-                httpOnly: cookies[i].httpOnly,
-                name: cookies[i].name,
-                value: cookies[i].value,
-                sameSite: cookies[i].sameSite,
-                path: cookies[i].path,
-                secure: cookies[i].secure,
-                storeId: cookies[i].storeId,
-                url: url
-            }
+            const dataUpdate = createCookieSetDetails(cookies[i], url);
             await chrome.cookies.set(dataUpdate);
             if (i === cookies.length - 1) {
                 settingStore.popup = "";

--- a/src/utils/cookie_import.js
+++ b/src/utils/cookie_import.js
@@ -1,0 +1,49 @@
+const HOST_PREFIX = "__Host-";
+const SECURE_PREFIX = "__Secure-";
+
+const shouldIncludeDomain = (cookie) => {
+    if (!cookie.domain || cookie.name?.startsWith(HOST_PREFIX)) {
+        return false;
+    }
+
+    if (cookie.hostOnly === false) {
+        return true;
+    }
+
+    return cookie.hostOnly === undefined && cookie.domain.startsWith(".");
+}
+
+export const createCookieSetDetails = (cookie, url) => {
+    const name = cookie.name || "";
+    const details = {
+        url,
+        name,
+        value: cookie.value || "",
+    };
+
+    if (cookie.expirationDate !== undefined && cookie.expirationDate !== null) {
+        details.expirationDate = Number(cookie.expirationDate);
+    }
+
+    if (cookie.httpOnly !== undefined) {
+        details.httpOnly = cookie.httpOnly;
+    }
+
+    if (cookie.sameSite) {
+        details.sameSite = cookie.sameSite;
+    }
+
+    if (cookie.storeId) {
+        details.storeId = cookie.storeId;
+    }
+
+    const secure = Boolean(cookie.secure || name.startsWith(SECURE_PREFIX) || name.startsWith(HOST_PREFIX));
+    details.secure = secure;
+    details.path = name.startsWith(HOST_PREFIX) ? "/" : (cookie.path || "/");
+
+    if (shouldIncludeDomain(cookie)) {
+        details.domain = cookie.domain;
+    }
+
+    return details;
+}

--- a/src/utils/cookie_import.test.js
+++ b/src/utils/cookie_import.test.js
@@ -1,0 +1,60 @@
+import {describe, expect, it} from "vitest";
+import {createCookieSetDetails} from "./cookie_import";
+
+describe("createCookieSetDetails", () => {
+    it("preserves domain cookies", () => {
+        expect(createCookieSetDetails({
+            domain: ".chatgpt.com",
+            hostOnly: false,
+            name: "oai-did",
+            path: "/",
+            value: "device",
+        }, "https://chatgpt.com")).toMatchObject({
+            domain: ".chatgpt.com",
+            name: "oai-did",
+            path: "/",
+            url: "https://chatgpt.com",
+            value: "device",
+        });
+    });
+
+    it("omits domain for host-only cookies", () => {
+        expect(createCookieSetDetails({
+            domain: "chatgpt.com",
+            hostOnly: true,
+            name: "g_state",
+            path: "/",
+            value: "state",
+        }, "https://chatgpt.com")).not.toHaveProperty("domain");
+    });
+
+    it("omits domain and enforces prefix requirements for __Host cookies", () => {
+        const details = createCookieSetDetails({
+            domain: ".chatgpt.com",
+            hostOnly: false,
+            name: "__Host-next-auth.csrf-token",
+            path: "/wrong",
+            secure: false,
+            value: "token",
+        }, "https://chatgpt.com");
+
+        expect(details).not.toHaveProperty("domain");
+        expect(details).toMatchObject({
+            path: "/",
+            secure: true,
+        });
+    });
+
+    it("enforces secure for __Secure cookies", () => {
+        expect(createCookieSetDetails({
+            domain: ".chatgpt.com",
+            hostOnly: false,
+            name: "__Secure-next-auth.session-token.0",
+            secure: false,
+            value: "token",
+        }, "https://chatgpt.com")).toMatchObject({
+            domain: ".chatgpt.com",
+            secure: true,
+        });
+    });
+});


### PR DESCRIPTION
## Summary

- Preserve `domain` when importing JSON cookies with `hostOnly: false`
- Keep host-only cookies and `__Host-` cookies domainless
- Share JSON import cookie detail construction across import flows
- Add tests for domain, host-only, `__Host-`, and `__Secure-` cases

## Problem

JSON exports include `domain` and `hostOnly`, but import currently calls `chrome.cookies.set` without passing `domain`.

When `domain` is omitted, Chrome creates a host-only cookie. A cookie exported as `.example.com` can be restored as `example.com`. If the server later sets `Domain=.example.com`, both cookies can coexist and produce duplicate `Cookie` header entries. With large cookies, this can contribute to `431 Request Header Fields Too Large`.

## Validation

- `npm test`
- `npm run build`